### PR TITLE
Fixes Issue #3

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,11 @@
 - **Vagrant VirtualBox Guest Additions Plugin**
   - `vagrant plugin install vagrant-vbguest`
   - *Last tested on version 0.10.0*
+- *A&D Repositories*
+  - you must have access to the following A&D Repositories:
+    * https://github.com/ackmann-dickenson/ansible_ruby
+    * https://github.com/ackmann-dickenson/ansible_common
+
 
 ### New Project Setup
 

--- a/skeleton/Vagrantfile.template
+++ b/skeleton/Vagrantfile.template
@@ -15,7 +15,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     dev.vm.synced_folder ".", "/home/vagrant/__APP_NAME__"
 
     dev.vm.box = "ubuntu/trusty64"
-    dev.vm.box_url = "http://files.vagrantup.com/trusty64.box"
     dev.vm.network :private_network, ip: "33.33.33.33"
     dev.vm.network "forwarded_port", guest: 3001, host: 3001
 


### PR DESCRIPTION
- Remove the `dev.vm.box_url` setting. The URL given was stale, which
  you wouldn't know as long as you've previously downloaded that box and
  it's in your local vagrant boxes. It's not necessary to specify it as
  vagrant knows enough to find the right box for that "official" box
  name.
- Add a note in the main README that you have to have ssh access to the
  A&D repos for `ansible_ruby` and `ansible_common`.
